### PR TITLE
Added support for using fileinfo extension for determining mimetype

### DIFF
--- a/lib/WideImage/MapperFactory.php
+++ b/lib/WideImage/MapperFactory.php
@@ -123,7 +123,16 @@ abstract class MapperFactory
 		$p = strrpos($uri, '.');
 		
 		if ($p === false) {
-			return '';
+			// if not found in extension, then try to use finfo_open (KS Development ApS improvement)
+			if(extension_loaded('fileinfo')) {
+				$finfo = finfo_open(FILEINFO_MIME_TYPE);
+				@$format = finfo_file($finfo, $uri);
+				finfo_close($finfo);
+
+				return ($format) ? $format : '';
+			} else {
+				return '';
+			}
 		}
 		
 		return substr($uri, $p + 1);


### PR DESCRIPTION
This improvement, makes it easier to use uploaded files, which is in temp directory under a temporary name. If no file extension is given, it tries to find it, by using FileInfo PHP extension - but only if it is loaded