### PR TITLE
Error Case mismatch

### DIFF
--- a/lib/WideImage/Operation/Merge.php
+++ b/lib/WideImage/Operation/Merge.php
@@ -21,7 +21,7 @@
     * @package Internal/Operations
   **/
 
-namespace WIdeImage\Operation;
+namespace WideImage\Operation;
 
 use WideImage\Coordinate;
 use WideImage\Exception\GDFunctionResultException;


### PR DESCRIPTION
Case mismatch between loaded and declared class names: WideImage\Operation\Merge vs WIdeImage\Operation\Merge