### PR TITLE
handle BMP with palette size not a power of 2

### DIFF
--- a/lib/vendor/de77/BMP.php
+++ b/lib/vendor/de77/BMP.php
@@ -128,7 +128,7 @@ class BMP
 
 		$bps    = $header['bits_per_pixel']; //bits per pixel
 	    $wid2   = ceil(($bps/8 * $header['width']) / 4) * 4;
-		$colors = pow(2, $bps);
+		$colors = $header['colors'];
 
 	    $wid = $header['width'];
 	    $hei = $header['height'];


### PR DESCRIPTION
The BMP palette size may be specified in the header.

This fixes https://github.com/SSilence/selfoss/issues/636