### PR TITLE
Fix handle validation on PHP 8

### DIFF
--- a/lib/WideImage.php
+++ b/lib/WideImage.php
@@ -349,7 +349,7 @@ class WideImage
 	 */
 	public static function isValidImageHandle($handle)
 	{
-		return (is_resource($handle) && get_resource_type($handle) == 'gd');
+		return ($handle instanceof \GdImage || (is_resource($handle) && get_resource_type($handle) == 'gd'));
 	}
 
 	/**

--- a/test/WideImage/Mapper/BMPTest.php
+++ b/test/WideImage/Mapper/BMPTest.php
@@ -60,7 +60,7 @@ class BMPTest extends WideImage_TestCase
 	public function testLoad($image, $width, $height)
 	{
 		$handle = $this->mapper->load($image);
-		$this->assertTrue(is_resource($handle));
+		$this->assertTrue(WideImage::isValidImageHandle($handle));
 		$this->assertEquals($width, imagesx($handle));
 		$this->assertEquals($height, imagesy($handle));
 		imagedestroy($handle);

--- a/test/WideImage/Mapper/GD2Test.php
+++ b/test/WideImage/Mapper/GD2Test.php
@@ -57,7 +57,7 @@ class GD2Test extends WideImage_TestCase
 		
 		// string contains valid image data
 		$handle = imagecreatefromstring($string);
-		$this->assertTrue(is_resource($handle));
+		$this->assertTrue(WideImage::isValidImageHandle($handle));
 		imagedestroy($handle);
 	}
 	

--- a/test/WideImage/Mapper/GIFTest.php
+++ b/test/WideImage/Mapper/GIFTest.php
@@ -21,6 +21,7 @@
 
 namespace Test\WideImage\Mapper;
 
+use WideImage\WideImage;
 use WideImage\MapperFactory;
 use Test\WideImage_TestCase;
 
@@ -51,7 +52,7 @@ class GIFTest extends WideImage_TestCase
 	public function testLoad()
 	{
 		$handle = $this->mapper->load(IMG_PATH . '100x100-color-hole.gif');
-		$this->assertTrue(is_resource($handle));
+		$this->assertTrue(WideImage::isValidImageHandle($handle));
 		$this->assertEquals(100, imagesx($handle));
 		$this->assertEquals(100, imagesy($handle));
 		imagedestroy($handle);
@@ -68,7 +69,7 @@ class GIFTest extends WideImage_TestCase
 		
 		// string contains valid image data
 		$handle = imagecreatefromstring($string);
-		$this->assertTrue(is_resource($handle));
+		$this->assertTrue(WideImage::isValidImageHandle($handle));
 		imagedestroy($handle);
 	}
 	
@@ -81,7 +82,7 @@ class GIFTest extends WideImage_TestCase
 		
 		// file is a valid image
 		$handle = imagecreatefromgif(IMG_PATH . 'temp' . DIRECTORY_SEPARATOR . 'test.gif');
-		$this->assertTrue(is_resource($handle));
+		$this->assertTrue(WideImage::isValidImageHandle($handle));
 		imagedestroy($handle);
 	}
 }

--- a/test/WideImage/Mapper/JPEGTest.php
+++ b/test/WideImage/Mapper/JPEGTest.php
@@ -21,6 +21,7 @@
 
 namespace Test\WideImage\Mapper;
 
+use WideImage\WideImage;
 use WideImage\MapperFactory;
 use Test\WideImage_TestCase;
 
@@ -48,7 +49,7 @@ class JPEGTest extends WideImage_TestCase
 	public function testLoad()
 	{
 		$handle = $this->mapper->load(IMG_PATH . 'fgnl.jpg');
-		$this->assertTrue(is_resource($handle));
+		$this->assertTrue(WideImage::isValidImageHandle($handle));
 		$this->assertEquals(174, imagesx($handle));
 		$this->assertEquals(287, imagesy($handle));
 		imagedestroy($handle);
@@ -65,7 +66,7 @@ class JPEGTest extends WideImage_TestCase
 		
 		// string contains valid image data
 		$handle = imagecreatefromstring($string);
-		$this->assertTrue(is_resource($handle));
+		$this->assertTrue(WideImage::isValidImageHandle($handle));
 		imagedestroy($handle);
 	}
 	
@@ -78,7 +79,7 @@ class JPEGTest extends WideImage_TestCase
 		
 		// file is a valid image
 		$handle = imagecreatefromjpeg(IMG_PATH . 'temp' . DIRECTORY_SEPARATOR . 'test.jpg');
-		$this->assertTrue(is_resource($handle));
+		$this->assertTrue(WideImage::isValidImageHandle($handle));
 		imagedestroy($handle);
 	}
 	

--- a/test/WideImage/Mapper/PNGTest.php
+++ b/test/WideImage/Mapper/PNGTest.php
@@ -21,6 +21,7 @@
 
 namespace Test\WideImage;
 
+use WideImage\WideImage;
 use WideImage\MapperFactory;
 use Test\WideImage_TestCase;
 
@@ -48,7 +49,7 @@ class PNGTest extends WideImage_TestCase
 	public function testLoad()
 	{
 		$handle = $this->mapper->load(IMG_PATH . '100x100-color-hole.png');
-		$this->assertTrue(is_resource($handle));
+		$this->assertTrue(WideImage::isValidImageHandle($handle));
 		$this->assertEquals(100, imagesx($handle));
 		$this->assertEquals(100, imagesy($handle));
 		imagedestroy($handle);
@@ -65,7 +66,7 @@ class PNGTest extends WideImage_TestCase
 		
 		// string contains valid image data
 		$handle = imagecreatefromstring($string);
-		$this->assertTrue(is_resource($handle));
+		$this->assertTrue(WideImage::isValidImageHandle($handle));
 		imagedestroy($handle);
 	}
 	
@@ -78,7 +79,7 @@ class PNGTest extends WideImage_TestCase
 		
 		// file is a valid image
 		$handle = imagecreatefrompng(IMG_PATH . 'temp/test.png');
-		$this->assertTrue(is_resource($handle));
+		$this->assertTrue(WideImage::isValidImageHandle($handle));
 		imagedestroy($handle);
 	}
 	

--- a/test/WideImage/Mapper/TGATest.php
+++ b/test/WideImage/Mapper/TGATest.php
@@ -21,6 +21,7 @@
 
 namespace Test\WideImage\Mapper;
 
+use WideImage\WideImage;
 use Test\WideImage_TestCase;
 use WideImage\MapperFactory;
 use WideImage\vendor\de77;
@@ -49,7 +50,7 @@ class TGATest extends WideImage_TestCase
 	public function testLoad()
 	{
 		$handle = $this->mapper->load(IMG_PATH . 'splat.tga');
-		$this->assertTrue(is_resource($handle));
+		$this->assertTrue(WideImage::isValidImageHandle($handle));
 		$this->assertEquals(100, imagesx($handle));
 		$this->assertEquals(100, imagesy($handle));
 		imagedestroy($handle);


### PR DESCRIPTION
PHP 8 switched GD handles from resource to `\GdImage` object:

https://php.watch/versions/8.0/gdimage

We need to update the checks appropriately.

Tested on loading PNG files in selfoss.
