### PR TITLE
tests: Allow running on widest range of PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-gd": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0",
+        "symfony/phpunit-bridge": "^5.2",
         "friendsofphp/php-cs-fixer": "~2.17"
     },
     "config": {

--- a/test/WideImage/CoordinateTest.php
+++ b/test/WideImage/CoordinateTest.php
@@ -100,11 +100,9 @@ class CoordinateTest extends WideImage_TestCase
         $this->assertSame(90, Coordinate::fix('100--++++-10', 200));
     }
     
-    /**
-     * @expectedException WideImage\Exception\InvalidCoordinateException
-     */
     public function testInvalidSyntaxEndsWithOperator()
     {
+        $this->expectException(\WideImage\Exception\InvalidCoordinateException::class);
         Coordinate::fix('5+2+', 10);
     }
 }

--- a/test/WideImage/Mapper/BMPTest.php
+++ b/test/WideImage/Mapper/BMPTest.php
@@ -37,12 +37,18 @@ class BMPTest extends WideImage_TestCase
      */
     protected $mapper;
 
-    public function setup()
+    /**
+     * @before
+     */
+    public function doSetUp()
     {
         $this->mapper = MapperFactory::selectMapper(null, 'bmp');
     }
 
-    public function teardown()
+    /**
+     * @after
+     */
+    public function doTearDown()
     {
         $this->mapper = null;
     }

--- a/test/WideImage/Mapper/GD2Test.php
+++ b/test/WideImage/Mapper/GD2Test.php
@@ -32,12 +32,18 @@ class GD2Test extends WideImage_TestCase
 {
     protected $mapper;
     
-    public function setup()
+    /**
+     * @before
+     */
+    public function doSetUp()
     {
         $this->mapper = MapperFactory::selectMapper(null, 'gd2');
     }
     
-    public function teardown()
+    /**
+     * @after
+     */
+    public function doTearDown()
     {
         $this->mapper = null;
         

--- a/test/WideImage/Mapper/GDTest.php
+++ b/test/WideImage/Mapper/GDTest.php
@@ -35,12 +35,18 @@ class GDTest extends WideImage_TestCase
      */
     protected $mapper;
     
-    public function setup()
+    /**
+     * @before
+     */
+    public function doSetUp()
     {
         $this->mapper = MapperFactory::selectMapper(null, 'gd');
     }
     
-    public function teardown()
+    /**
+     * @after
+     */
+    public function doTearDown()
     {
         $this->mapper = null;
         

--- a/test/WideImage/Mapper/GIFTest.php
+++ b/test/WideImage/Mapper/GIFTest.php
@@ -35,12 +35,18 @@ class GIFTest extends WideImage_TestCase
 {
     protected $mapper;
     
-    public function setup()
+    /**
+     * @before
+     */
+    public function doSetUp()
     {
         $this->mapper = MapperFactory::selectMapper(null, 'gif');
     }
     
-    public function teardown()
+    /**
+     * @after
+     */
+    public function doTearDown()
     {
         $this->mapper = null;
         

--- a/test/WideImage/Mapper/JPEGTest.php
+++ b/test/WideImage/Mapper/JPEGTest.php
@@ -32,12 +32,18 @@ class JPEGTest extends WideImage_TestCase
 {
     protected $mapper;
     
-    public function setup()
+    /**
+     * @before
+     */
+    public function doSetUp()
     {
         $this->mapper = MapperFactory::selectMapper(null, 'jpg');
     }
     
-    public function teardown()
+    /**
+     * @after
+     */
+    public function doTearDown()
     {
         $this->mapper = null;
         

--- a/test/WideImage/Mapper/PNGTest.php
+++ b/test/WideImage/Mapper/PNGTest.php
@@ -32,12 +32,18 @@ class PNGTest extends WideImage_TestCase
 {
     protected $mapper;
     
-    public function setup()
+    /**
+     * @before
+     */
+    public function doSetUp()
     {
         $this->mapper = MapperFactory::selectMapper(null, 'png');
     }
     
-    public function teardown()
+    /**
+     * @after
+     */
+    public function doTearDown()
     {
         $this->mapper = null;
         

--- a/test/WideImage/Mapper/TGATest.php
+++ b/test/WideImage/Mapper/TGATest.php
@@ -62,20 +62,16 @@ class TGATest extends WideImage_TestCase
         imagedestroy($handle);
     }
     
-    /**
-     * @expectedException WideImage\Exception\Exception
-     */
     public function testSaveToStringNotSupported()
     {
+        $this->expectException(\WideImage\Exception\Exception::class);
         $handle = de77\BMP::imagecreatefrombmp(IMG_PATH . 'splat.tga');
         $this->mapper->save($handle);
     }
     
-    /**
-     * @expectedException WideImage\Exception\Exception
-     */
     public function testSaveToFileNotSupported()
     {
+        $this->expectException(\WideImage\Exception\Exception::class);
         $handle = imagecreatefromgif(IMG_PATH . '100x100-color-hole.gif');
         $this->mapper->save($handle, IMG_PATH . 'temp' . DIRECTORY_SEPARATOR . 'test.bmp');
     }

--- a/test/WideImage/Mapper/TGATest.php
+++ b/test/WideImage/Mapper/TGATest.php
@@ -37,12 +37,18 @@ class TGATest extends WideImage_TestCase
      */
     protected $mapper;
     
-    public function setup()
+    /**
+     * @before
+     */
+    public function doSetUp()
     {
         $this->mapper = MapperFactory::selectMapper(null, 'tga');
     }
     
-    public function teardown()
+    /**
+     * @after
+     */
+    public function doTearDown()
     {
         $this->mapper = null;
     }

--- a/test/WideImage/Operation/CropTest.php
+++ b/test/WideImage/Operation/CropTest.php
@@ -93,20 +93,16 @@ class CropTest extends WideImage_TestCase
         $this->assertEquals(100, $cropped->getHeight());
     }
 
-    /**
-     * @expectedException WideImage\Exception\Exception
-     */
     public function testCropCutsAreaOutsideBoundaries()
     {
+        $this->expectException(\WideImage\Exception\Exception::class);
         $img = WideImage::load(IMG_PATH . '100x100-blue-alpha.png');
         $img->crop(120, 100, 1, 2);
     }
 
-    /**
-     * @expectedException WideImage\Exception\Exception
-     */
     public function testCropCutsAreaNegativePosition()
     {
+        $this->expectException(\WideImage\Exception\Exception::class);
         $img = WideImage::load(IMG_PATH . '100x100-blue-alpha.png');
         $img->crop(-150, -200, 50, 50);
     }

--- a/test/WideImage/OperationFactoryTest.php
+++ b/test/WideImage/OperationFactoryTest.php
@@ -39,11 +39,9 @@ class OperationFactoryTest extends WideImage_TestCase
         $this->assertSame($op1, $op2);
     }
 
-    /**
-     * @expectedException WideImage\Exception\UnknownImageOperationException
-     */
     public function testNoOperation()
     {
+        $this->expectException(\WideImage\Exception\UnknownImageOperationException::class);
         OperationFactory::get('NoSuchOp');
     }
 

--- a/test/WideImage/WideImageTest.php
+++ b/test/WideImage/WideImageTest.php
@@ -39,13 +39,19 @@ class WideImageTest extends WideImage_TestCase
 {
     protected $_FILES;
 
-    public function setup()
+    /**
+     * @before
+     */
+    public function doSetUp()
     {
         $this->_FILES = $_FILES;
         $_FILES = [];
     }
 
-    public function teardown()
+    /**
+     * @after
+     */
+    public function doTearDown()
     {
         $_FILES = $this->_FILES;
 

--- a/test/WideImage/WideImageTest.php
+++ b/test/WideImage/WideImageTest.php
@@ -157,7 +157,13 @@ class WideImageTest extends WideImage_TestCase
         ];
 
         $images = WideImage::loadFromUpload('testupl');
-        $this->assertInternalType("array", $images);
+        if (method_exists($this, 'assertIsArray')) {
+            // PHPUnit ≥ 8.0
+            $this->assertIsArray($images);
+        } else {
+            // PHPUnit < 8.0
+            $this->assertInternalType("array", $images);
+        }
         $this->assertValidImage($images[0]);
         $this->assertValidImage($images[1]);
 
@@ -218,11 +224,9 @@ class WideImageTest extends WideImage_TestCase
         $this->assertValidImage($img);
     }
 
-    /**
-     * @expectedException WideImage\Exception\InvalidImageSourceException
-     */
     public function testLoadFromStringEmpty()
     {
+        $this->expectException(InvalidImageSourceException::class);
         WideImage::loadFromString('');
     }
 
@@ -281,43 +285,33 @@ class WideImageTest extends WideImage_TestCase
         $this->assertEquals('out', $str);
     }
 
-    /**
-     * @expectedException \WideImage\Exception\InvalidImageSourceException
-     */
     public function testInvalidImageFile()
     {
+        $this->expectException(InvalidImageSourceException::class);
         WideImage::loadFromFile(IMG_PATH . 'fakeimage.png');
     }
 
-    /**
-     * @expectedException WideImage\Exception\InvalidImageSourceException
-     */
     public function testEmptyString()
     {
+        $this->expectException(InvalidImageSourceException::class);
         WideImage::load('');
     }
 
-    /**
-     * @expectedException WideImage\Exception\InvalidImageSourceException
-     */
     public function testInvalidImageStringData()
     {
+        $this->expectException(InvalidImageSourceException::class);
         WideImage::loadFromString('asdf');
     }
 
-    /**
-     * @expectedException WideImage\Exception\InvalidImageSourceException
-     */
     public function testInvalidImageHandle()
     {
+        $this->expectException(InvalidImageSourceException::class);
         WideImage::loadFromHandle(0);
     }
 
-    /**
-     * @expectedException WideImage\Exception\InvalidImageSourceException
-     */
     public function testInvalidImageUploadField()
     {
+        $this->expectException(InvalidImageSourceException::class);
         WideImage::loadFromUpload('xyz');
     }
 }

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,1 +1,1 @@
-../bin/phpunit $* --verbose --bootstrap `dirname $0`/test-init.php `dirname $0`/WideImage
+`dirname $0`/../vendor/bin/simple-phpunit $* --verbose --bootstrap `dirname $0`/test-init.php `dirname $0`/WideImage

--- a/test/test-init.php
+++ b/test/test-init.php
@@ -14,7 +14,7 @@ if (ini_get('xdebug.scream')) {
     ini_set('xdebug.scream', 0);
 }
 
-abstract class WideImage_TestCase extends \PHPUnit_Framework_TestCase
+abstract class WideImage_TestCase extends \PHPUnit\Framework\TestCase
 {
     public function load($file)
     {


### PR DESCRIPTION
PHPUnit 8 introduces return annotations which make tests incompatible with PHP < 7.1. Let’s use Symfony’s PHPUnit wrapper to achieve the largest support base possible.

Some tests still do not pass but at least they do not crash on any of PHP 5.6 – 8.0.
